### PR TITLE
feat: Refactor buffer to use a single slice and add tests

### DIFF
--- a/buffer.go
+++ b/buffer.go
@@ -1,68 +1,176 @@
 package pim
 
-import "iter"
+import (
+	"fmt"
+	"iter"
+)
+
+var (
+	lineEndingRune = rune('\n')
+)
+
+const (
+	initialBufferSize = 1024 // Initial size of the buffer
+)
 
 type Buffer struct {
-	buffer [][]rune
-	// cursor represents the current position in the buffer.
-	// The position is represented as a row and column and it is 0-indexed.
-	// In EditMode, the current position is where the next character will be inserted.
-	// In CommandMode, the cursor position is where the command will be executed.
-	cursor Cursor
+	// buffer is a slice of runes that stores the entire text content of the editor,
+	// including newline characters. Using `rune` (Go's representation for a Unicode code point)
+	// ensures correct handling of multi-byte UTF-8 characters, preventing issues where
+	// editing operations might truncate or corrupt characters. This means indexing into
+	// 'buffer' is by Unicode character (rune) count, not raw byte count.
+	//
+	// This buffer is designed with an "extra space at the end" strategy. It may have
+	// a capacity greater than its current 'size', allowing for efficient insertions
+	// and deletions by shifting runes within the existing allocated memory,
+	// minimizing the need for frequent reallocations until the capacity is exhausted.
+	buffer []rune
+	// lineIndex is a slice of integers where each element stores the starting index
+	// (in terms of rune count from the beginning of the 'buffer') of a corresponding line.
+	// Each index represents the position where a new character would be inserted
+	// if typing at the very beginning of that line.
+	//
+	// Important Implementation Details:
+	// - The index for the first line (Line 0) *is* stored at lineIndex[0], which will always be 0.
+	//   This simplifies line lookups (e.g., line N's start is lineIndex[N]).
+	// - The length of 'lineIndex' will be equal to the total number of lines in the buffer.
+	lineIndex []int
+	// cursorLine represents the current line number within the buffer.
+	// It is 0-indexed.
+	cursorLine int
+	// cursorCol represents the current character (rune) offset from the beginning of the current line.
+	// It is 0-indexed.
+	cursorCol int
+	// size is the current number of runes (characters) present in the 'buffer'.
+	// This explicitly tracks the logical length of the text, distinct from the
+	// underlying 'buffer' slice's capacity.
+	len int
 }
 
 func NewBuffer() *Buffer {
 	return &Buffer{
-		buffer: make([][]rune, 1),
-		cursor: Cursor{
-			Row: 0,
-			Col: 0,
-		},
+		buffer:    make([]rune, 1024),
+		lineIndex: []int{0},
 	}
 }
 
-func (buffer *Buffer) InsertChars(chars []rune) {
-	// TODO: insert at cursor position not at the end
-	buffer.buffer[buffer.cursor.Row] = append(buffer.buffer[buffer.cursor.Row], chars...)
-	buffer.cursor.Col += len(chars)
+func (buffer *Buffer) lookupRCIdx(row, col int) int {
+	return buffer.lookupLineIdx(row) + col
 }
 
-func (buffer *Buffer) DeleteChar() bool {
+func (b *Buffer) cursorIdx() int {
+	return b.lookupRCIdx(b.cursorLine, b.cursorCol)
+}
 
-	if buffer.cursor.Col > 0 {
-		// Delete the character before the cursor
-		buffer.buffer[buffer.cursor.Row] = append(buffer.buffer[buffer.cursor.Row][:buffer.cursor.Col-1],
-			buffer.buffer[buffer.cursor.Row][buffer.cursor.Col:]...)
-		buffer.cursor.Col--
-		return true
-	} else if buffer.cursor.Row > 0 {
-		// No more to delete from current line
-		// Delete current line and move up to the last character of the previous line if exist
-		buffer.buffer = buffer.buffer[:buffer.cursor.Row]
+func (buffer *Buffer) numLines() int {
+	return len(buffer.lineIndex)
+}
 
-		buffer.cursor.Row--
-		buffer.cursor.Col = len(buffer.buffer[buffer.cursor.Row])
+func (buffer *Buffer) lookupLineIdx(n int) int {
+	if n < 0 || n >= len(buffer.lineIndex) {
+		panic(fmt.Sprintf("index out of range: %d", n))
 	}
 
-	return false
+	return buffer.lineIndex[n]
+}
+
+// insertRune insert the character to the current cursor positions.
+// All the characters to the right of the original cursor position are shifted to the right by one position.
+// insertRune only modify the state of the buffer, it does not update the cursor position or the line index.
+func (buffer *Buffer) insertRune(char rune) {
+	// Allocate more space if needed
+	if len(buffer.buffer) < buffer.len+1 {
+		buffer.buffer = make([]rune, len(buffer.buffer)*2)
+		copy(buffer.buffer, buffer.buffer[:buffer.len])
+	}
+
+	// 1. Shift over the characters to the right of the cursor
+	// 2. Update the line index
+	copy(buffer.buffer[buffer.cursorIdx()+1:], buffer.buffer[buffer.cursorIdx():])
+	buffer.buffer[buffer.cursorIdx()] = char
+	buffer.len++
+}
+
+func (buffer *Buffer) InsertRune(char rune) {
+	buffer.insertRune(char)
+
+	// Update the line index
+	for i := buffer.cursorLine + 1; i < len(buffer.lineIndex); i++ {
+		buffer.lineIndex[i]++
+	}
+
+	// Update the cursor position
+	buffer.cursorCol++
+}
+
+func (b *Buffer) lineLen(n int) int {
+	if n < 0 || n >= len(b.lineIndex) {
+		panic(fmt.Sprintf("line index out of range: %d", n))
+	}
+
+	if n < len(b.lineIndex)-1 {
+		return b.lineIndex[n+1] - b.lineIndex[n]
+	}
+
+	return b.len - b.lineIndex[n]
+}
+
+func (b *Buffer) DeleteRune() bool {
+
+	if b.cursorIdx() < 1 {
+		return false
+	}
+
+	// 1. Shift characters to the right of the cursor by 1 position
+	// 2. Decrement line indexes of the lines after the cursor by one
+	b.buffer[b.cursorIdx()] = 0 // Clear the character at the cursor position
+	copy(b.buffer[b.cursorIdx()-1:], b.buffer[b.cursorIdx():])
+	b.len--
+
+	if b.cursorCol > 0 {
+		b.cursorCol--
+		for i := b.cursorLine + 1; i < len(b.lineIndex); i++ {
+			b.lineIndex[i]--
+		}
+	} else if b.cursorLine > 0 {
+		// Delete the deleted line from the line index
+		copy(b.lineIndex[b.cursorLine:], b.lineIndex[b.cursorLine+1:])
+		b.lineIndex = b.lineIndex[:len(b.lineIndex)-1]
+
+		b.cursorLine--
+		for i := b.cursorLine + 1; i < len(b.lineIndex); i++ {
+			b.lineIndex[i]--
+		}
+
+		b.cursorCol = b.lineLen(b.cursorLine)
+
+	}
+
+	return true
 
 }
 
-func (buffer *Buffer) InsertNewLineBelow() {
-	buffer.buffer = append(buffer.buffer, []rune{})
-	buffer.cursor.Row++
-	buffer.cursor.Col = 0
+// NewLine inserts a new line at the cursor position and move the cursor to the left one position.
+func (b *Buffer) NewLine() {
+	b.insertRune(lineEndingRune)
+
+	b.lineIndex = append(b.lineIndex, 0)
+	copy(b.lineIndex[b.cursorLine+2:], b.lineIndex[b.cursorLine:])
+	b.lineIndex[b.cursorLine+1] = b.lookupRCIdx(b.cursorLine, b.cursorCol) + 1
+
+	b.cursorLine++
+	for i := b.cursorLine + 1; i < len(b.lineIndex); i++ {
+		b.lineIndex[i]++
+	}
+
+	b.cursorCol = 0
+
 }
 
-type Cursor struct {
-	Row int
-	Col int
-}
-
-func (buffer *Buffer) Lines() iter.Seq[[]rune] {
-	return func(yield func([]rune) bool) {
-		for _, line := range buffer.buffer {
-			if !yield(line) {
+func (buffer *Buffer) Runes() iter.Seq[rune] {
+	return func(yield func(rune) bool) {
+		for _, r := range buffer.buffer {
+			if !yield(r) {
 				return
 			}
 		}
@@ -70,5 +178,5 @@ func (buffer *Buffer) Lines() iter.Seq[[]rune] {
 }
 
 func (buffer *Buffer) CursorPosition() (row, col int) {
-	return buffer.cursor.Row, buffer.cursor.Col
+	return buffer.cursorLine, buffer.cursorCol
 }

--- a/buffer_test.go
+++ b/buffer_test.go
@@ -1,0 +1,96 @@
+package pim
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestBuffer_NewBuffer(t *testing.T) {
+	b := NewBuffer()
+	assertBufferState(t, defaultBufferState(), *b)
+}
+
+func TestBuffer_InsertRune(t *testing.T) {
+	b := NewBuffer()
+
+	b.InsertRune('r')
+	assertBufferState(t, bufferState{
+		cursorLine: 0,
+		cursorCol:  1,
+		len:        1,
+		buffer:     []rune{'r'},
+		lineIdx:    []int{0},
+	}, *b)
+}
+
+func TestBuffer_NewLine(t *testing.T) {
+	b := NewBuffer()
+
+	b.NewLine()
+	assertBufferState(t, bufferState{
+		cursorLine: 1,
+		cursorCol:  0,
+		len:        1,
+		buffer:     []rune{'\n'},
+		lineIdx:    []int{0, 1},
+	}, *b)
+}
+
+func TestBuffer_DeleteRune(t *testing.T) {
+	b := NewBuffer()
+	b.InsertRune('r')
+
+	b.DeleteRune()
+	assertBufferState(t, bufferState{
+		cursorLine: 0,
+		cursorCol:  0,
+		len:        0,
+		buffer:     []rune{},
+		lineIdx:    []int{0},
+	}, *b)
+
+	b.NewLine()
+	assertBufferState(t, bufferState{
+		cursorLine: 1,
+		cursorCol:  0,
+		len:        1,
+		buffer:     []rune{'\n'},
+		lineIdx:    []int{0, 1},
+	}, *b)
+
+	b.DeleteRune()
+	assertBufferState(t, bufferState{
+		cursorLine: 0,
+		cursorCol:  0,
+		len:        0,
+		buffer:     []rune{},
+		lineIdx:    []int{0},
+	}, *b)
+}
+
+type bufferState struct {
+	cursorLine int
+	cursorCol  int
+	len        int
+	buffer     []rune
+	lineIdx    []int
+}
+
+func defaultBufferState() bufferState {
+	return bufferState{
+		cursorLine: 0,
+		cursorCol:  0,
+		len:        0,
+		buffer:     []rune{},
+		lineIdx:    []int{0},
+	}
+}
+
+func assertBufferState(t *testing.T, exp bufferState, act Buffer) {
+	assert.Equal(t, exp.cursorLine, act.cursorLine, "Cursor Line mismatch")
+	assert.Equal(t, exp.cursorCol, act.cursorCol, "Cursor Col mismatch")
+	assert.Equal(t, exp.len, act.len, "Buffer length mismatch")
+	assert.Equal(t, exp.buffer, act.buffer[:act.len], "Buffer content mismatch")
+	assert.Equal(t, exp.lineIdx, act.lineIndex, "Line index mismatch")
+}

--- a/go.mod
+++ b/go.mod
@@ -3,8 +3,15 @@ module github/putto11262002/pim
 go 1.24.0
 
 require (
-	atomicgo.dev/keyboard v0.2.9 // indirect
+	atomicgo.dev/keyboard v0.2.9
+	golang.org/x/term v0.32.0
+)
+
+require (
 	github.com/containerd/console v1.0.3 // indirect
+	github.com/davecgh/go-spew v1.1.1 // indirect
+	github.com/pmezard/go-difflib v1.0.0 // indirect
+	github.com/stretchr/testify v1.10.0 // indirect
 	golang.org/x/sys v0.33.0 // indirect
-	golang.org/x/term v0.32.0 // indirect
+	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/go.sum
+++ b/go.sum
@@ -11,6 +11,7 @@ github.com/atomicgo/cursor v0.0.1/go.mod h1:cBON2QmmrysudxNBFthvMtN32r3jxVRIvzkU
 github.com/containerd/console v1.0.3 h1:lIr7SlA5PxZyMV30bDW0MGbiOPXwc63yRuCP0ARubLw=
 github.com/containerd/console v1.0.3/go.mod h1:7LqA/THxQ86k76b8c/EMSiaJ3h1eZkMkXar0TQ1gf3U=
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
+github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/gookit/color v1.4.2/go.mod h1:fqRyamkC1W8uxl+lxCQxOT09l/vYfZ+QeiX3rKQHCoQ=
 github.com/gookit/color v1.5.0/go.mod h1:43aQb+Zerm/BWh2GnrgOQm7ffz7tvQXEKV6BFMl7wAo=
@@ -21,6 +22,7 @@ github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORN
 github.com/kr/pty v1.1.1/go.mod h1:pFQYn66WHrOpPYNljwOMqo10TkYh1fy3cYio2l3bCsQ=
 github.com/kr/text v0.1.0/go.mod h1:4Jbv+DJW3UT/LiOwJeYQe1efqtUx/iVham/4vfdArNI=
 github.com/mattn/go-runewidth v0.0.13/go.mod h1:Jdepj2loyihRzMpdS35Xk/zdY8IAYHsh153qUoGf23w=
+github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/pterm/pterm v0.12.27/go.mod h1:PhQ89w4i95rhgE+xedAoqous6K9X+r6aSOI2eFF7DZI=
 github.com/pterm/pterm v0.12.29/go.mod h1:WI3qxgvoQFFGKGjGnJR849gU0TsEOvKn5Q8LlY1U7lg=
@@ -35,6 +37,8 @@ github.com/stretchr/objx v0.1.0/go.mod h1:HFkY916IF+rwdDfMAkV7OtwuqBVzrE8GR6GFx+
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
 github.com/stretchr/testify v1.7.0/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stretchr/testify v1.10.0 h1:Xv5erBjTwe/5IxqUQTdXv5kgmIvbHo3QQyRwhJsOfJA=
+github.com/stretchr/testify v1.10.0/go.mod h1:r2ic/lqez/lEtzL7wO/rwa5dbSLXVDPFyf8C91i36aY=
 github.com/xo/terminfo v0.0.0-20210125001918-ca9a967f8778/go.mod h1:2MuV+tbUrU1zIOPMxZ5EncGwgmMJsa+9ucAQZXxsObs=
 golang.org/x/sys v0.0.0-20201119102817-f84b799fce68/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
 golang.org/x/sys v0.0.0-20210124154548-22da62e12c0c/go.mod h1:h1NjWce9XRLGQEsW7wpKNCjG9DtNlClVuFLEZdDNbEs=
@@ -56,3 +60,5 @@ gopkg.in/yaml.v2 v2.2.2/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20210107192922-496545a6307b/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/main.go
+++ b/main.go
@@ -57,11 +57,13 @@ func (e *Editor) Execute(key keys.Key) error {
 		case keys.Esc:
 			e.SetMode(CommandMode)
 		case keys.Backspace:
-			e.buffer.DeleteChar()
+			e.buffer.DeleteRune()
 		case keys.Enter:
-			e.buffer.InsertNewLineBelow()
+			e.buffer.NewLine()
 		default:
-			e.buffer.InsertChars(key.Runes)
+			for _, c := range key.Runes {
+				e.buffer.InsertRune(c)
+			}
 		}
 	}
 

--- a/renderer.go
+++ b/renderer.go
@@ -104,11 +104,8 @@ func (r *Renderer) Render(editor *Editor) error {
 	}
 
 	// Render the buffer
-	for line := range editor.buffer.Lines() {
-		for _, char := range line {
-			fmt.Fprint(r.writer, string(char))
-		}
-		fmt.Fprintln(r.writer) // Move to the next line after each line of text
+	for char := range editor.buffer.Runes() {
+		fmt.Fprint(r.writer, string(char))
 	}
 
 	// Move the cursor to the current position


### PR DESCRIPTION
Refactor the internal text buffer representation from a slice of rune slices ([][]rune) to a single contiguous rune slice ([]rune).

This change improves memory locality by storing all text data in a single block, which can lead to better performance for editing operations. A line index ([]int) is introduced to maintain the starting position of each line within the flat buffer, allowing for efficient line-based navigation.

Additionally, this commit introduces initial unit tests for the core buffer operations (insertion, deletion, new lines) to ensure correctness and prevent regressions.